### PR TITLE
fix: masternode UI freeze

### DIFF
--- a/src/qt/forms/masternodemanager.ui
+++ b/src/qt/forms/masternodemanager.ui
@@ -62,11 +62,6 @@
            </column>
            <column>
             <property name="text">
-             <string>Rank</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
              <string>Active</string>
             </property>
            </column>

--- a/src/qt/masternodemanager.cpp
+++ b/src/qt/masternodemanager.cpp
@@ -161,7 +161,7 @@ void MasternodeManager::updateNodeList()
 	// Address, Rank, Active, Active Seconds, Last Seen, Pub Key
 	QTableWidgetItem *activeItem = new QTableWidgetItem(QString::number(mn.IsEnabled()));
 	QTableWidgetItem *addressItem = new QTableWidgetItem(QString::fromStdString(mn.addr.ToString()));
-	QTableWidgetItem *rankItem = new QTableWidgetItem(QString::number(GetMasternodeRank(mn.vin, pindexBest->nHeight)));
+    //QTableWidgetItem *rankItem = new QTableWidgetItem(QString::number(GetMasternodeRank(mn.vin, pindexBest->nHeight)));
 	QTableWidgetItem *activeSecondsItem = new QTableWidgetItem(seconds_to_DHMS((qint64)(mn.lastTimeSeen - mn.now)));
 	QTableWidgetItem *lastSeenItem = new QTableWidgetItem(QString::fromStdString(DateTimeStrFormat(mn.lastTimeSeen)));
 	
@@ -173,11 +173,11 @@ void MasternodeManager::updateNodeList()
 	QTableWidgetItem *pubkeyItem = new QTableWidgetItem(QString::fromStdString(address2.ToString()));
 	
 	ui->tableWidget->setItem(mnRow, 0, addressItem);
-	ui->tableWidget->setItem(mnRow, 1, rankItem);
-	ui->tableWidget->setItem(mnRow, 2, activeItem);
-	ui->tableWidget->setItem(mnRow, 3, activeSecondsItem);
-	ui->tableWidget->setItem(mnRow, 4, lastSeenItem);
-	ui->tableWidget->setItem(mnRow, 5, pubkeyItem);
+    //ui->tableWidget->setItem(mnRow, 1, rankItem);
+    ui->tableWidget->setItem(mnRow, 1, activeItem);
+    ui->tableWidget->setItem(mnRow, 2, activeSecondsItem);
+    ui->tableWidget->setItem(mnRow, 3, lastSeenItem);
+    ui->tableWidget->setItem(mnRow, 4, pubkeyItem);
     }
 
     ui->countLabel->setText(QString::number(ui->tableWidget->rowCount()));


### PR DESCRIPTION
Masternode UI freezes when the *Rank* column is present.